### PR TITLE
Adding archive support

### DIFF
--- a/tubeup.py
+++ b/tubeup.py
@@ -67,7 +67,7 @@ def download(URLs, proxy_url):
     
     ydl_opts = {
         'outtmpl': 'downloads/%(title)s-%(id)s.%(ext)s',
-#        'download_archive': 'downloads/.ytdlarchive', # I guess we will avoid doing this because it prevents failed uploads from being redone in our current system. Maybe when we turn it into an OOP library?
+        'download_archive': 'downloads/.ytdlarchive', 
         'restrictfilenames': True,
         'verbose': True,
         'progress_with_newline': True,


### PR DESCRIPTION
Uncomented line and moved archive location for a few reasons:

- No, it doesn't add to the archive on failed downloads. Only on merge or completion if I recall. ```--continue``` equivalent enabled already so this shouldn't be an issue
- Speeds repeated channel rips

The archive isn't vital but really speeds archival of channels and saves on space:

- I repeatedly tested pre-change, trying to upload a video twice to see if it makes an item twice. It does not clobber the old item nor add to the first run item, nor does it add duplicate files to first item.
- Old videos can be safely expunged from the downloads folder (perhaps adding pruning flag so people can electively have ```downloads/``` contents purged on final upload completion).
- It allowed people to create a batch file to be run in a crontab that will re-check the channels and download and then upload only new content.


Final notes: 
- ```downloads/``` is a terrible place to put the archive file, due to the risk of it accidentally being wiped. Putting it in the root of the scripts folder would be wiser.
- I couldn't use my current archive file (same filename but in ~/), so I just injected it's contents into the tubeup copy (```cat ~/.ytdlarchive >> ~/git/tubeup/downloads/.ytdlarchive```)