### PR TITLE
Fix `--quiet` mode in tubeup

### DIFF
--- a/tests/test_tubeup.py
+++ b/tests/test_tubeup.py
@@ -6,7 +6,9 @@ import time
 import requests_mock
 import glob
 
-from tubeup.TubeUp import TubeUp, log, DOWNLOAD_DIR_NAME
+from logging import Logger
+from tubeup.TubeUp import TubeUp, DOWNLOAD_DIR_NAME
+from tubeup.utils import LogErrorToStdout
 
 
 current_path = os.path.dirname(os.path.realpath(__file__))
@@ -66,6 +68,15 @@ class TubeUpTests(unittest.TestCase):
         # Clean the test directory
         shutil.rmtree(root_path, ignore_errors=True)
 
+    def test_tubeup_attribute_logger_when_quiet_mode(self):
+        # self.tu is already `TubeUp` instance with quiet mode, so we don't
+        # create a new instance here.
+        self.assertIsInstance(self.tu.logger, LogErrorToStdout)
+
+    def test_tubeup_attribute_logger_when_verbose_mode(self):
+        tu = TubeUp(verbose=True)
+        self.assertIsInstance(tu.logger, Logger)
+
     def test_determine_collection_type(self):
         soundcloud_colltype = self.tu.determine_collection_type(
             'https://soundcloud.com/testurl')
@@ -104,7 +115,7 @@ class TubeUpTests(unittest.TestCase):
             'consoletitle': True,
             'prefer_ffmpeg': True,
             'call_home': False,
-            'logger': log,
+            'logger': self.tu.logger,
             'progress_hooks': [mocked_ydl_progress_hook]}
 
         self.assertEqual(result, expected_result)
@@ -138,7 +149,7 @@ class TubeUpTests(unittest.TestCase):
             'consoletitle': True,
             'prefer_ffmpeg': True,
             'call_home': False,
-            'logger': log,
+            'logger': self.tu.logger,
             'progress_hooks': [mocked_ydl_progress_hook],
             'proxy': 'http://proxytest.com:8080'}
 
@@ -174,7 +185,7 @@ class TubeUpTests(unittest.TestCase):
             'consoletitle': True,
             'prefer_ffmpeg': True,
             'call_home': False,
-            'logger': log,
+            'logger': self.tu.logger,
             'progress_hooks': [mocked_ydl_progress_hook],
             'username': 'testUsername',
             'password': 'testPassword'}

--- a/tests/test_tubeup.py
+++ b/tests/test_tubeup.py
@@ -97,6 +97,7 @@ class TubeUpTests(unittest.TestCase):
                                              '.ytdlarchive'),
             'restrictfilenames': True,
             'verbose': False,
+            'quiet': True,
             'progress_with_newline': True,
             'forcetitle': True,
             'continuedl': True,
@@ -131,6 +132,7 @@ class TubeUpTests(unittest.TestCase):
                                              '.ytdlarchive'),
             'restrictfilenames': True,
             'verbose': False,
+            'quiet': True,
             'progress_with_newline': True,
             'forcetitle': True,
             'continuedl': True,
@@ -167,6 +169,7 @@ class TubeUpTests(unittest.TestCase):
                                              '.ytdlarchive'),
             'restrictfilenames': True,
             'verbose': False,
+            'quiet': True,
             'progress_with_newline': True,
             'forcetitle': True,
             'continuedl': True,
@@ -186,6 +189,45 @@ class TubeUpTests(unittest.TestCase):
             'prefer_ffmpeg': True,
             'call_home': False,
             'logger': self.tu.logger,
+            'progress_hooks': [mocked_ydl_progress_hook],
+            'username': 'testUsername',
+            'password': 'testPassword'}
+
+        self.assertEqual(result, expected_result)
+
+    def test_generate_ydl_options_with_verbose_mode(self):
+        tu = TubeUp(verbose=True)
+        result = tu.generate_ydl_options(
+            mocked_ydl_progress_hook, ydl_username='testUsername',
+            ydl_password='testPassword')
+
+        expected_result = {
+            'outtmpl': os.path.join(
+                self.tu.dir_path['downloads'], '%(title)s-%(id)s.%(ext)s'),
+            'download_archive': os.path.join(self.tu.dir_path['root'],
+                                             '.ytdlarchive'),
+            'restrictfilenames': True,
+            'verbose': True,
+            'quiet': False,
+            'progress_with_newline': True,
+            'forcetitle': True,
+            'continuedl': True,
+            'retries': 9001,
+            'fragment_retries': 9001,
+            'forcejson': True,
+            'writeinfojson': True,
+            'writedescription': True,
+            'writethumbnail': True,
+            'writeannotations': True,
+            'writesubtitles': True,
+            'allsubtitles': True,
+            'ignoreerrors': True,
+            'fixup': 'warn',
+            'nooverwrites': True,
+            'consoletitle': True,
+            'prefer_ffmpeg': True,
+            'call_home': False,
+            'logger': tu.logger,
             'progress_hooks': [mocked_ydl_progress_hook],
             'username': 'testUsername',
             'password': 'testPassword'}

--- a/tests/test_tubeup.py
+++ b/tests/test_tubeup.py
@@ -79,12 +79,9 @@ class TubeUpTests(unittest.TestCase):
     def test_generate_ydl_options(self):
         result = self.tu.generate_ydl_options(mocked_ydl_progress_hook)
 
-        download_path = os.path.join(
-            os.path.expanduser('~/.tubeup'), DOWNLOAD_DIR_NAME)
-
         expected_result = {
             'outtmpl': os.path.join(
-                download_path, '%(title)s-%(id)s.%(ext)s'),
+                self.tu.dir_path['downloads'], '%(title)s-%(id)s.%(ext)s'),
             'download_archive': os.path.join(self.tu.dir_path['root'],
                                              '.ytdlarchive'),
             'restrictfilenames': True,
@@ -116,12 +113,9 @@ class TubeUpTests(unittest.TestCase):
         result = self.tu.generate_ydl_options(
             mocked_ydl_progress_hook, proxy_url='http://proxytest.com:8080')
 
-        download_path = os.path.join(
-            os.path.expanduser('~/.tubeup'), DOWNLOAD_DIR_NAME)
-
         expected_result = {
             'outtmpl': os.path.join(
-                download_path, '%(title)s-%(id)s.%(ext)s'),
+                self.tu.dir_path['downloads'], '%(title)s-%(id)s.%(ext)s'),
             'download_archive': os.path.join(self.tu.dir_path['root'],
                                              '.ytdlarchive'),
             'restrictfilenames': True,
@@ -155,12 +149,9 @@ class TubeUpTests(unittest.TestCase):
             mocked_ydl_progress_hook, ydl_username='testUsername',
             ydl_password='testPassword')
 
-        download_path = os.path.join(
-            os.path.expanduser('~/.tubeup'), DOWNLOAD_DIR_NAME)
-
         expected_result = {
             'outtmpl': os.path.join(
-                download_path, '%(title)s-%(id)s.%(ext)s'),
+                self.tu.dir_path['downloads'], '%(title)s-%(id)s.%(ext)s'),
             'download_archive': os.path.join(self.tu.dir_path['root'],
                                              '.ytdlarchive'),
             'restrictfilenames': True,

--- a/tubeup/TubeUp.py
+++ b/tubeup/TubeUp.py
@@ -174,6 +174,7 @@ class TubeUp(object):
                                              '.ytdlarchive'),
 
             'restrictfilenames': True,
+            'quiet': not self.verbose,
             'verbose': self.verbose,
             'progress_with_newline': True,
             'forcetitle': True,

--- a/tubeup/TubeUp.py
+++ b/tubeup/TubeUp.py
@@ -18,9 +18,6 @@ from urllib.parse import urlparse
 DOWNLOAD_DIR_NAME = 'downloads'
 
 
-log = getLogger(__name__)
-
-
 class TubeUp(object):
 
     def __init__(self,
@@ -42,6 +39,8 @@ class TubeUp(object):
         self.dir_path = dir_path
         self.verbose = verbose
         self.ia_config_path = ia_config_path
+        self.logger = (getLogger(__name__) if self.verbose  # Just print errors
+                       else LogErrorToStdout())             # in quiet mode
 
     @property
     def dir_path(self):
@@ -113,8 +112,8 @@ class TubeUp(object):
             if d['status'] == 'finished':
                 msg = 'Downloaded %s' % d['filename']
 
-                log.debug(d)
-                log.info(msg)
+                self.logger.debug(d)
+                self.logger.info(msg)
                 if self.verbose:
                     print('\n%s' % d)
                     print(msg)
@@ -123,7 +122,7 @@ class TubeUp(object):
                 # TODO: Complete the error message
                 msg = 'Error when downloading the video'
 
-                log.error(msg)
+                self.logger.error(msg)
                 if self.verbose:
                     print(msg)
 
@@ -203,8 +202,7 @@ class TubeUp(object):
             # Warns on out of date youtube-dl script, helps debugging for
             # youtube-dl devs
             'call_home': False,
-            'logger': (LogErrorToStdout() if self.verbose
-                       else log),
+            'logger': self.logger,
             'progress_hooks': [ydl_progress_hook]
         }
 
@@ -270,7 +268,7 @@ class TubeUp(object):
             msg = ('`internetarchive` configuration file is not configured'
                    ' properly.')
 
-            log.error(msg)
+            self.logger.error(msg)
             if self.verbose:
                 print(msg)
             raise Exception(msg)


### PR DESCRIPTION
FIx --quote mode still prints video doesn't have a subtitle when there's no subtitle by adding quote flag to youtube_dl opts.