### PR TITLE
Make some dependencies' version fixed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,8 @@ setup(
         ],
     },
     install_requires=[
-        'internetarchive>=1.0.0',
-        'docopt',
+        'internetarchive==1.7.4',
+        'docopt==0.6.2',
         'youtube-dl',
     ]
 )

--- a/tests/test_tubeup.py
+++ b/tests/test_tubeup.py
@@ -380,7 +380,7 @@ class TubeUpTests(unittest.TestCase):
                              'Nature;Mountain;'),
                  'originalurl': 'https://www.youtube.com/watch?v=6iRV8liah8A',
                  'licenseurl': '',
-                 'scanner': 'Internet Archive Python library 1.7.3'})
+                 'scanner': 'Internet Archive Python library 1.7.4'})
 
             self.assertEqual(expected_result, result)
 
@@ -442,6 +442,6 @@ class TubeUpTests(unittest.TestCase):
                              'Nature;Mountain;'),
                  'originalurl': 'https://www.youtube.com/watch?v=6iRV8liah8A',
                  'licenseurl': '',
-                 'scanner': 'Internet Archive Python library 1.7.3'})]
+                 'scanner': 'Internet Archive Python library 1.7.4'})]
 
             self.assertEqual(expected_result, result)


### PR DESCRIPTION
Make some dependencies' version fixed, especially for internetarchive
and docopt, since they're not always releasing its new version
very often, and to make sure the program is working same
on everyone's computer.