### PR TITLE
Twitter/Twitch Support

### DIFF
--- a/tubeup/TubeUp.py
+++ b/tubeup/TubeUp.py
@@ -276,7 +276,7 @@ class TubeUp(object):
         itemname = ('%s-%s' % (vid_meta['extractor'],
                                vid_meta['display_id']))
 
-        # Strip out illegal characters from identifer
+        # Replace illegal characters within identifer
         itemname = re.sub('\W+', '-', itemname)
 
         metadata = self.create_archive_org_metadata_from_youtubedl_meta(

--- a/tubeup/TubeUp.py
+++ b/tubeup/TubeUp.py
@@ -276,6 +276,9 @@ class TubeUp(object):
         itemname = ('%s-%s' % (vid_meta['extractor'],
                                vid_meta['display_id']))
 
+        # Strip out illegal characters from identifer
+        itemname = re.sub('\W+', '-', itemname)
+
         metadata = self.create_archive_org_metadata_from_youtubedl_meta(
             vid_meta)
 


### PR DESCRIPTION
Addresses https://github.com/bibanon/tubeup/issues/47

Symptom: Some video extractors youtube-dl supports include non-alphanumeric characters the Internet Archive considers illegal (`:` for example).

Fix: Replace any non-alphanumeric characters in the item identifier with hyphens.

Tests pass after this change:
```
➜  tubeup git:(twitter-twitch-support) ✗ pytest --cov
==================================================================== test session starts ====================================================================
platform darwin -- Python 3.6.3, pytest-3.3.0, py-1.5.2, pluggy-0.6.0
rootdir: /Users/brandon/Projects/brandongalbraith/tubeup, inifile:
plugins: cov-2.5.1
collected 19 items                                                                                                                                          

tests/test_tubeup.py .................                                                                                                                [ 89%]
tests/test_utils.py ..                                                                                                                                [100%]

---------- coverage: platform darwin, python 3.6.3-final-0 -----------
Name                 Stmts   Miss Branch BrPart  Cover   Missing
----------------------------------------------------------------
tubeup/TubeUp.py       151     35     58      6    71%   93-131, 289, 295, 305, 313-319, 391-392, 287->289, 292->295, 304->305, 312->313, 409->414, 414->419
tubeup/__init__.py       0      0      0      0   100%
tubeup/__main__.py      35     35      6      0     0%   18-98
tubeup/utils.py         11      2      0      0    82%   23, 26
----------------------------------------------------------------
TOTAL                  197     72     64      6    60%


================================================================= 19 passed in 7.48 seconds =================================================================
```