### PR TITLE
Update internetarchive version in testcases

### DIFF
--- a/tests/test_tubeup.py
+++ b/tests/test_tubeup.py
@@ -489,7 +489,7 @@ class TubeUpTests(unittest.TestCase):
                              'Nature;Mountain;'),
                  'originalurl': 'https://www.youtube.com/watch?v=6iRV8liah8A',
                  'licenseurl': '',
-                 'scanner': 'Internet Archive Python library 1.7.4'})
+                 'scanner': 'Internet Archive Python library 1.7.6'})
 
             self.assertEqual(expected_result, result)
 
@@ -558,6 +558,6 @@ class TubeUpTests(unittest.TestCase):
                              'Nature;Mountain;'),
                  'originalurl': 'https://www.youtube.com/watch?v=6iRV8liah8A',
                  'licenseurl': '',
-                 'scanner': 'Internet Archive Python library 1.7.4'})]
+                 'scanner': 'Internet Archive Python library 1.7.6'})]
 
             self.assertEqual(expected_result, result)


### PR DESCRIPTION
Update internetarchive version in testcases
from 1.7.4 to 1.7.6, so testcases don't fail.