### PR TITLE
.travis.yml: Create job for Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: python
+dist: xenial
 python:
   - "3.5"
   - "3.6"
+  - "3.7"
   # - "3.3" # deactivated because internetarchive's setup script is broken in this
             # version of Python
             # https://travis-ci.org/bibanon/tubeup/jobs/538770585#L528


### PR DESCRIPTION
Also add `dist: xenial`, so that Travis uses Ubuntu Xenial for our jobs
instead of Ubuntu Trusty, which is EOL, and there's a problem in
Travis' ubuntu Trusty that there's no Python 3.7 archive for it.
(https://travis-ci.community/t/unable-to-download-python-3-7-archive-on-travis-ci/639)

Per discussion on
https://github.com/bibanon/tubeup/pull/93#issuecomment-498001928