### PR TITLE
Fix quiet mode: 'LogErrorToStdout' object has no attribute 'info'

### DIFF
--- a/tubeup/TubeUp.py
+++ b/tubeup/TubeUp.py
@@ -4,13 +4,13 @@ import re
 import glob
 import time
 import json
+import logging
 import internetarchive
 
 from internetarchive.config import parse_config_file
 from datetime import datetime
 from youtube_dl import YoutubeDL
-from .utils import (check_is_file_empty, EMPTY_ANNOTATION_FILE,
-                    LogErrorToStdout)
+from .utils import (check_is_file_empty, EMPTY_ANNOTATION_FILE)
 from logging import getLogger
 from urllib.parse import urlparse
 
@@ -41,8 +41,11 @@ class TubeUp(object):
         self.dir_path = dir_path
         self.verbose = verbose
         self.ia_config_path = ia_config_path
-        self.logger = (getLogger(__name__) if self.verbose  # Just print errors
-                       else LogErrorToStdout())             # in quiet mode
+        self.logger = getLogger(__name__)
+
+        # Just print errors in quiet mode
+        if not self.verbose:
+            self.logger.setLevel(logging.ERROR)
 
     @property
     def dir_path(self):

--- a/tubeup/utils.py
+++ b/tubeup/utils.py
@@ -16,14 +16,3 @@ def check_is_file_empty(filepath):
         return os.stat(filepath).st_size == 0
     else:
         raise FileNotFoundError("Path '%s' doesn't exist" % filepath)
-
-
-class LogErrorToStdout(object):
-    def debug(self, msg):
-        pass
-
-    def warning(self, msg):
-        pass
-
-    def error(self, msg):
-        print(msg)


### PR DESCRIPTION
`--quiet` mode is currently broken because `LogErrorToStdout` cannot handle `info` messages.
This also means TubeUp crashes when imported as a library as this becomes the default unless you pass `verbose=True` when instantiating the TubeUp instance.

`ydl_progress_hook` uses `self.logger.info()` which raises an `AttributeError`.
This in turn I believe causes `info_dict` to become `None`. So eventually TubeUp crashes with `AttributeError: 'NoneType' object has no attribute 'get'` in `create_basenames_from_ydl_info_dict`.

This fix uses `self.logger.setLevel(logging.ERROR)` which made `LogErrorToStdout` pointless.