### PR TITLE
tests: ensure all tests work locally

### DIFF
--- a/tests/test_tubeup.py
+++ b/tests/test_tubeup.py
@@ -429,11 +429,11 @@ class TubeUpTests(unittest.TestCase):
         copy_testfiles_to_tubeup_rootdir_test()
 
         result = tu.get_resource_basenames(
-            ['https://www.youtube.com/watch?v=6iRV8liah8A'])
+            ['https://www.youtube.com/watch?v=KdsN9YhkDrY'])
 
         expected_result = {os.path.join(
             current_path, 'test_tubeup_rootdir', 'downloads',
-            'Mountain_3_-_Video_Background_HD_1080p-6iRV8liah8A')}
+            'KdsN9YhkDrY')}
 
         self.assertEqual(expected_result, result)
 
@@ -514,7 +514,7 @@ class TubeUpTests(unittest.TestCase):
 
         videobasename = os.path.join(
             current_path, 'test_tubeup_rootdir', 'downloads',
-            'Mountain_3_-_Video_Background_HD_1080p-6iRV8liah8A')
+            'KdsN9YhkDrY')
 
         copy_testfiles_to_tubeup_rootdir_test()
 
@@ -526,7 +526,7 @@ class TubeUpTests(unittest.TestCase):
                   content=b'{"over_limit": 0}',
                   headers={'content-type': 'application/json'})
 
-            m.get('https://archive.org/metadata/youtube-6iRV8liah8A',
+            m.get('https://archive.org/metadata/youtube-KdsN9YhkDrY',
                   content=b'{}',
                   headers={'content-type': 'application/json'})
 
@@ -534,37 +534,39 @@ class TubeUpTests(unittest.TestCase):
             # in mock_upload_response_by_videobasename(), so this test
             # doesn't perform upload to the real archive.org server.
             mock_upload_response_by_videobasename(
-                m, 'youtube-6iRV8liah8A', videobasename)
+                m, 'youtube-KdsN9YhkDrY', videobasename)
 
             result = list(tu.archive_urls(
-                ['https://www.youtube.com/watch?v=6iRV8liah8A']))
+                ['https://www.youtube.com/watch?v=KdsN9YhkDrY']))
 
             expected_result = [(
-                'youtube-6iRV8liah8A',
+                'youtube-KdsN9YhkDrY',
                 {'mediatype': 'movies',
-                 'creator': 'Video Background',
+                 'creator': 'RelaxingWorld',
                  'collection': 'opensource_movies',
-                 'title': 'Mountain 3 - Video Background HD 1080p',
-                 'description': ('Mountain 3 - Video Background HD 1080p<br>If '
-                                 'you use this video please put credits to my'
-                                 ' channel in description:<br>https://www.youtub'
-                                 'e.com/channel/UCWpsozCMdAnfI16rZHQ9XDg<br>© D'
-                                 'on\'t forget to SUBSCRIBE, LIKE, COMMENT an'
-                                 'd RATE. Hope you all enjoy! <br/><br/>Sourc'
-                                 'e: <a href="https://www.youtube.com/watch?v'
-                                 '=6iRV8liah8A">https://www.youtube.com/watch'
-                                 '?v=6iRV8liah8A</a><br/>Uploader: <a href="h'
-                                 'ttp://www.youtube.com/channel/UCWpsozCMdAnf'
-                                 'I16rZHQ9XDg">Video Background</a>'),
-                 'date': '2015-01-05',
-                 'year': '2015',
-                 'subject': ('Youtube;video;Entertainment;Video Background;'
-                             'Footage;Animation;Cinema;stock video footage;'
-                             'Royalty free videos;Creative Commons videos;'
-                             'free movies online;youtube;HD;1080p;Amazing '
-                             'Nature;Mountain;'),
-                 'originalurl': 'https://www.youtube.com/watch?v=6iRV8liah8A',
-                 'licenseurl': 'https://creativecommons.org/licenses/by/3.0/',
+                 'title': 'Epic Ramadan - Video Background HD1080p',
+                 'description': ('If you enjoy my work, please consider Subscribe to my NEW '
+                                 'channel for more videos: <br>'
+                                 'https://www.youtube.com/MusicForRelaxation?sub_confirmation=1 <br>'
+                                 '▷ If you use this video, please put credits to my channel '
+                                 'in description: <br>'
+                                 'Source from RelaxingWorld: https://goo.gl/HsW75m<br>'
+                                 '<br>'
+                                 '▷ Also, do not forget to Subscribe to my channel. Thanks! '
+                                 '<br/><br/>Source: <a '
+                                 'href="https://www.youtube.com/watch?v=KdsN9YhkDrY">https://www.youtube.com/watch?v=KdsN9YhkDrY</a><br/>Uploader: '
+                                 '<a '
+                                 'href="http://www.youtube.com/channel/UCWpsozCMdAnfI16rZHQ9XDg">RelaxingWorld</a>'
+                                 ),
+                 'date': '2016-06-25',
+                 'year': '2016',
+                 'subject': ('Youtube;video;Film & Animation;Video Background;'
+                             'Footage;Animation;Cinema;Royalty Free Videos;'
+                             'Stock Video Footage;Video Backdrops;'
+                             'Amazing Nature;youtube;HD;1080p;Creative Commons Videos;'
+                             'relaxing music;Ramadan;'),
+                 'originalurl': 'https://www.youtube.com/watch?v=KdsN9YhkDrY',
+                 'licenseurl': '',
                  'scanner': SCANNER})]
 
             self.assertEqual(expected_result, result)

--- a/tests/test_tubeup.py
+++ b/tests/test_tubeup.py
@@ -127,7 +127,7 @@ class TubeUpTests(unittest.TestCase):
 
         expected_result = {
             'outtmpl': os.path.join(
-                self.tu.dir_path['downloads'], '%(title)s-%(id)s.%(ext)s'),
+                self.tu.dir_path['downloads'], '%(id)s.%(ext)s'),
             'restrictfilenames': True,
             'verbose': False,
             'quiet': True,
@@ -161,7 +161,7 @@ class TubeUpTests(unittest.TestCase):
 
         expected_result = {
             'outtmpl': os.path.join(
-                self.tu.dir_path['downloads'], '%(title)s-%(id)s.%(ext)s'),
+                self.tu.dir_path['downloads'], '%(id)s.%(ext)s'),
             'restrictfilenames': True,
             'verbose': False,
             'quiet': True,
@@ -194,7 +194,7 @@ class TubeUpTests(unittest.TestCase):
 
         expected_result = {
             'outtmpl': os.path.join(
-                self.tu.dir_path['downloads'], '%(title)s-%(id)s.%(ext)s'),
+                self.tu.dir_path['downloads'], '%(id)s.%(ext)s'),
             'restrictfilenames': True,
             'verbose': False,
             'quiet': True,
@@ -229,7 +229,7 @@ class TubeUpTests(unittest.TestCase):
 
         expected_result = {
             'outtmpl': os.path.join(
-                self.tu.dir_path['downloads'], '%(title)s-%(id)s.%(ext)s'),
+                self.tu.dir_path['downloads'], '%(id)s.%(ext)s'),
             'restrictfilenames': True,
             'verbose': False,
             'quiet': True,
@@ -266,7 +266,7 @@ class TubeUpTests(unittest.TestCase):
 
         expected_result = {
             'outtmpl': os.path.join(
-                self.tu.dir_path['downloads'], '%(title)s-%(id)s.%(ext)s'),
+                self.tu.dir_path['downloads'], '%(id)s.%(ext)s'),
             'restrictfilenames': True,
             'verbose': True,
             'quiet': False,

--- a/tests/test_tubeup.py
+++ b/tests/test_tubeup.py
@@ -5,10 +5,9 @@ import json
 import time
 import requests_mock
 import glob
+import logging
 
-from logging import Logger
 from tubeup.TubeUp import TubeUp, DOWNLOAD_DIR_NAME
-from tubeup.utils import LogErrorToStdout
 from tubeup import __version__
 from youtube_dl import YoutubeDL
 from .constants import info_dict_playlist, info_dict_video
@@ -76,11 +75,12 @@ class TubeUpTests(unittest.TestCase):
     def test_tubeup_attribute_logger_when_quiet_mode(self):
         # self.tu is already `TubeUp` instance with quiet mode, so we don't
         # create a new instance here.
-        self.assertIsInstance(self.tu.logger, LogErrorToStdout)
+        self.assertIsInstance(self.tu.logger, logging.Logger)
+        self.assertEqual(self.tu.logger.level, logging.ERROR)
 
     def test_tubeup_attribute_logger_when_verbose_mode(self):
         tu = TubeUp(verbose=True)
-        self.assertIsInstance(tu.logger, Logger)
+        self.assertIsInstance(tu.logger, logging.Logger)
 
     def test_determine_collection_type(self):
         soundcloud_colltype = self.tu.determine_collection_type(


### PR DESCRIPTION
Two tests were failing because they try to access a video no longer on YouTube: I pointed them at another short video by the same user, but a more permanent fix would be to access a mocked video (or at least a custom one that's less likely to be removed). You also might want to move them into a different file for better separation between the unit tests (fast) and the integration tests (slow).

Many tests were failing because the download path was wrong: that's an easy fix!

Finally, the logger tests just referred to a deleted method.

This will conflict with #141 : ping me when you merge either and I'll correct the other. It's quite a straightforward change: the '\n' in the definition here has to become \<br>.