### PR TITLE
Add --write-metadata option to export metadata as CSV

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Usage:
                   [--quiet] [--debug]
                   [--use-download-archive]
                   [--output <output>]
+                  [--write-metadata]
   tubeup -h | --help
   tubeup --version
 
@@ -100,6 +101,7 @@ Options:
   --quiet                   Just print errors.
   --debug                   Print all logs to stdout.
   --output <output>         Youtube-dlc output template.
+  --write-metadata          Write item metadata as CSV to a file.
 
 ```
 
@@ -113,8 +115,9 @@ You can specify a different collection with the `--metadata` flag:
    tubeup --metadata=collection:opensource_audio <url>
 ```
 
-Any arbitrary metadta can be added to the item, with a few exceptions.
+Any arbitrary metadata can be added to the item, with a few exceptions.
 You can learn more about archive.org metadata [here](https://archive.org/services/docs/api/metadata-schema/).
+The resulting metadata may be exported to CSV files by specifying the `--write-metadata` flag.
 
 ### Collections
 

--- a/tubeup/TubeUp.py
+++ b/tubeup/TubeUp.py
@@ -321,10 +321,11 @@ class TubeUp(object):
             metadata.update(custom_meta)
 
         if write_metadata:
+            csv_metadata = dict(identifier=itemname, **metadata)
             with open('%s.csv' % itemname, 'w', encoding='utf-8', newline='') as f:
-                w = csv.DictWriter(f, metadata.keys())
+                w = csv.DictWriter(f, csv_metadata.keys())
                 w.writeheader()
-                w.writerow(metadata)
+                w.writerow(csv_metadata)
 
         # Parse internetarchive configuration file.
         parsed_ia_s3_config = parse_config_file(self.ia_config_path)[1]['s3']

--- a/tubeup/__main__.py
+++ b/tubeup/__main__.py
@@ -24,6 +24,7 @@ Usage:
                   [--quiet] [--debug]
                   [--use-download-archive]
                   [--output <output>]
+                  [--write-metadata]
   tubeup -h | --help
   tubeup --version
 
@@ -46,6 +47,7 @@ Options:
   --quiet                   Just print errors.
   --debug                   Print all logs to stdout.
   --output <output>         Youtube-dlc output template.
+  --write-metadata          Write item metadata as CSV to a file.
 """
 
 import sys
@@ -71,6 +73,7 @@ def main():
     quiet_mode = args['--quiet']
     debug_mode = args['--debug']
     use_download_archive = args['--use-download-archive']
+    write_metadata = args['--write-metadata']
 
     if debug_mode:
         # Display log messages.
@@ -93,7 +96,8 @@ def main():
     try:
         for identifier, meta in tu.archive_urls(URLs, metadata, proxy_url,
                                                 username, password,
-                                                use_download_archive):
+                                                use_download_archive,
+                                                write_metadata):
             print('\n:: Upload Finished. Item information:')
             print('Title: %s' % meta['title'])
             print('Upload URL: https://archive.org/details/%s\n' % identifier)


### PR DESCRIPTION
The resulting files can be read by "ia metadata". This may be useful to make minor corrections to an item's metadata in the event the extractor didn't do its job properly (e.g. in the case of https://github.com/ytdl-org/youtube-dl/issues/25937) or when certain keywords in an video's description trip archive.org's spam filter (#135).