### PR TITLE
Fix regular expression for valid identifiers

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,9 +1,32 @@
 import unittest
 import os
-from tubeup.utils import check_is_file_empty
+from tubeup.utils import sanitize_identifier, check_is_file_empty
 
 
 class UtilsTest(unittest.TestCase):
+
+    def test_preserve_valid_identifiers(self):
+        valid = [
+            'youtube--QBwhSklJks',
+            'youtube-_--M04_mN-M',
+            'youtube-Xy2jZABDB40'
+        ]
+        clean = [sanitize_identifier(x) for x in valid]
+        self.assertListEqual(valid, clean)
+
+    def test_sanitize_bad_identifiers(self):
+        bad = [
+            'twitch:vod-v181464551',
+            'twitch:clips-1003820974',
+            'twitter:card-1192732384065708032'
+        ]
+        expect = [
+            'twitch-vod-v181464551',
+            'twitch-clips-1003820974',
+            'twitter-card-1192732384065708032'
+        ]
+        clean = [sanitize_identifier(x) for x in bad]
+        self.assertListEqual(expect, clean)
 
     def test_check_is_file_empty_when_file_is_empty(self):
         # Create a file for the test

--- a/tubeup/TubeUp.py
+++ b/tubeup/TubeUp.py
@@ -288,7 +288,7 @@ class TubeUp(object):
                                vid_meta['display_id']))
 
         # Replace illegal characters within identifer
-        itemname = re.sub(r'\W+', '-', itemname)
+        itemname = re.sub(r'[^\w-]', '-', itemname)
 
         metadata = self.create_archive_org_metadata_from_youtubedl_meta(
             vid_meta)

--- a/tubeup/TubeUp.py
+++ b/tubeup/TubeUp.py
@@ -10,7 +10,8 @@ import internetarchive
 from internetarchive.config import parse_config_file
 from datetime import datetime
 from youtube_dl import YoutubeDL
-from .utils import (check_is_file_empty, EMPTY_ANNOTATION_FILE)
+from .utils import (sanitize_identifier, check_is_file_empty,
+                    EMPTY_ANNOTATION_FILE)
 from logging import getLogger
 from urllib.parse import urlparse
 
@@ -288,7 +289,7 @@ class TubeUp(object):
                                vid_meta['display_id']))
 
         # Replace illegal characters within identifer
-        itemname = re.sub(r'[^\w-]', '-', itemname)
+        itemname = sanitize_identifier(itemname)
 
         metadata = self.create_archive_org_metadata_from_youtubedl_meta(
             vid_meta)

--- a/tubeup/utils.py
+++ b/tubeup/utils.py
@@ -1,8 +1,13 @@
 import os
+import re
 
 
 EMPTY_ANNOTATION_FILE = ('<?xml version="1.0" encoding="UTF-8" ?>'
                          '<document><annotations></annotations></document>')
+
+
+def sanitize_identifier(identifier, replacement='-'):
+    return re.sub(r'[^\w-]', replacement, identifier)
 
 
 def check_is_file_empty(filepath):


### PR DESCRIPTION
Seeing as previous attempts to fix #88 didn't go anywhere, I decided to do it myself.
The issue with the previous expression was two-fold:
* The use of the `\W` metacharacter. This short-hand is equivalent to `[^a-zA-Z0-9_]`, meaning match any characters which don't belong to the set of letters, digits or, underscore (`_`). However, this set notoriously does not include the dash (`-`), yet this is perfectly valid in both Internet Archive and YouTube identifiers.
> An identifier is composed of a unique combination of alphanumeric characters (limited to ASCII), underscores (_), dashes (-), or periods (.). [[source](https://archive.org/services/docs/api/metadata-schema/index.html#archive-org-identifiers)]

* The use of the greedy `+` quantifier for the purposes of substituting single characters. This quantifier will match the preceding token between one to unlimited times, as many times as possible. This will result in streaks of "invalid" characters being replaced as a single valid character.

These two issues combined cause the quirky behaviour observed from tubeup's item naming:
* If the first character of a YouTube video identifier begins with a dash, the item will be missing the dash (#88)
Let's take `-QBwhSklJks`, tubeup will form the item name as `extractor + "-" + video_identifier`.
This results in `youtube--QBwhSklJks`. However, it then applies the problematic expression and matches "--" as a streak of invalid characters, replacing them with a single "-", finally ending up with `youtube-QBwhSklJks`.
* If the YouTube identifier contains several dashes in a row, they will appear as one (https://github.com/bibanon/tubeup/issues/88#issuecomment-503356252)
Now that we understand what went wrong with the previous example, it's clear what's going on here. Let's take `_--M04_mN-M`.
Again the problematic expression matches the two dashes as a streak of invalid characters, replacing them with a single one: `youtube-_-M04_mN-M`

The fix:
* Adding the dash to the valid set of characters: `[^a-zA-Z0-9_-]`, or by taking advantage of the `\w` metacharacter, `[^\w-]`
`\W` is the complement to `\w`, hence `\W` = `[^\w]`. The usage of `^` denotes that it should match characters NOT in the set.
* Removing the `+` quantifier. `re.sub` will replace every match of the regular expression, by removing the quantifier from it, every character will be replaced one to one, avoiding instances of collapsed sequences of characters. Note that if this would have been omitted from the start, the above two examples wouldn't have been an issue as, despite the dash being absent from the matched set, it would be replaced by itself, which causes no harm.