### PR TITLE
fix: set description_text to blank if it is null

### DIFF
--- a/tests/test_tubeup.py
+++ b/tests/test_tubeup.py
@@ -333,6 +333,21 @@ class TubeUpTests(unittest.TestCase):
 
         self.assertEqual(expected_result, result)
 
+    def test_create_archive_org_metadata_from_youtubedl_meta_description_text_null(self):
+        with open(get_testfile_path(
+                'description_text_null.json')
+                ) as f:
+            vid_meta = json.load(f)
+
+        result = TubeUp.create_archive_org_metadata_from_youtubedl_meta(
+            vid_meta
+        )
+
+        expected_description = (' <br/><br/>Source: <a href="url">url</a><br/>'
+                                'Uploader: <a href="url">tubeup.py</a>')
+
+        self.assertEqual(expected_description, result.get('description'))
+
     def test_create_archive_org_metadata_from_youtubedl_meta_no_uploader(self):
         with open(get_testfile_path(
                 'Mountain_3_-_Video_Background_HD_1080p-6iRV8liah8A.info_no_'

--- a/tests/test_tubeup_files/description_text_null.json
+++ b/tests/test_tubeup_files/description_text_null.json
@@ -1,0 +1,6 @@
+{
+	"title": "Null description text",
+	"webpage_url": "url",
+	"extractor_key": "dummy",
+	"description_text": null
+}

--- a/tests/test_tubeup_files/description_text_null.json
+++ b/tests/test_tubeup_files/description_text_null.json
@@ -2,5 +2,5 @@
 	"title": "Null description text",
 	"webpage_url": "url",
 	"extractor_key": "dummy",
-	"description_text": null
+	"description": null
 }

--- a/tubeup/TubeUp.py
+++ b/tubeup/TubeUp.py
@@ -472,6 +472,8 @@ class TubeUp(object):
 
         # if there is no description don't upload the empty .description file
         description_text = vid_meta.get('description', '')
+        if description_text is None:
+            description_text = ''
         # archive.org does not display raw newlines
         description_text = re.sub('\r?\n', '<br>', description_text)
 


### PR DESCRIPTION
Fixes #154, I hope. Untested because I don't know of a good video, but I hope someone else does.

If a JSON file contains something like:
```
{
  "description": null
}
```

then `a = json.load(f); a.get('description', '')` returned `None` instead of `''`. This meant passing `description_text` into `re.sub` failed.

I replace `None` with `''` instead of only doing the replacement on a valid description because `'{0}'.format(None)` is `None`, and I think having nothing in the description is better than the word "None".