### PR TITLE
Don't print JSON to the terminal

### DIFF
--- a/tubeup/TubeUp.py
+++ b/tubeup/TubeUp.py
@@ -235,7 +235,7 @@ class TubeUp(object):
             'continuedl': True,
             'retries': 9001,
             'fragment_retries': 9001,
-            'forcejson': True,
+            'forcejson': False,
             'writeinfojson': True,
             'writedescription': True,
             'writethumbnail': True,


### PR DESCRIPTION
The JSON printed to the terminal is already written to disk as basename.info.json, printing to the console is redundant IMHO.