### PR TITLE
Fix failing tests

### DIFF
--- a/tests/test_tubeup.py
+++ b/tests/test_tubeup.py
@@ -596,7 +596,7 @@ class TubeUpTests(unittest.TestCase):
                              'Amazing Nature;youtube;HD;1080p;Creative Commons Videos;'
                              'relaxing music;Ramadan;'),
                  'originalurl': 'https://www.youtube.com/watch?v=KdsN9YhkDrY',
-                 'licenseurl': 'https://creativecommons.org/licenses/by/3.0/',
+                 'licenseurl': '',
                  'scanner': SCANNER})]
 
             self.assertEqual(expected_result, result)


### PR DESCRIPTION
Looks like Youtube aren't returning the license url for this anymore?