### PR TITLE
Compatibility with internetarchive>2.0.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         ],
     },
     install_requires=[
-        'internetarchive>2.0.3',
+        'internetarchive',
         'docopt==0.6.2',
         'yt-dlp',
     ]

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         ],
     },
     install_requires=[
-        'internetarchive==2.0.3',
+        'internetarchive>2.0.3',
         'docopt==0.6.2',
         'yt-dlp',
     ]

--- a/tubeup/TubeUp.py
+++ b/tubeup/TubeUp.py
@@ -341,7 +341,7 @@ class TubeUp(object):
             metadata.update(custom_meta)
 
         # Parse internetarchive configuration file.
-        parsed_ia_s3_config = parse_config_file(self.ia_config_path)[1]['s3']
+        parsed_ia_s3_config = parse_config_file(self.ia_config_path)[2]['s3']
         s3_access_key = parsed_ia_s3_config['access']
         s3_secret_key = parsed_ia_s3_config['secret']
 


### PR DESCRIPTION
Closes #172

In internetarchive v2.1.0 they put an is_xdg boolean flag in the return tuple where the config used to be, so we just have to accomodate for this by taking the 3rd value of parse_config_file instead of the second.