### PR TITLE
Add python version 3.10 to test matrix

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -8,11 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version:
-          - 3.7
-          - 3.8
-          - 3.9
-          - 3.10
+        python-version: ['3.7', '3.8', '3.9', '3.10']
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -12,6 +12,7 @@ jobs:
           - 3.7
           - 3.8
           - 3.9
+          - 3.10
 
     steps:
       - uses: actions/checkout@v2

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
-pytest==3.2.3
-pytest-cov==2.5.1
+pytest==7.1.2
+pytest-cov==3.0.0
 requests-mock==1.3.0
 flake8==3.4.1

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
 pytest==7.1.2
 pytest-cov==3.0.0
-requests-mock==1.3.0
-flake8==3.4.1
+requests-mock==1.9.3
+flake8==4.0.1


### PR DESCRIPTION
Python 3.10 has been released for some time, and with new performance improvements expected in Python 3.11, we want to be ready. This PR bumps forward all of our test dependencies to their latest versions and also adds Python 3.10 as a version we test against.