### PR TITLE
Don't use playlist URL when checking if an item exists

### DIFF
--- a/tubeup/TubeUp.py
+++ b/tubeup/TubeUp.py
@@ -184,7 +184,7 @@ class TubeUp(object):
                             else:
                                 ydl.record_download_archive(entry)
                     else:
-                        if ydl.in_download_archive(entry):
+                        if ydl.in_download_archive(info_dict):
                             continue
                         if check_if_ia_item_exists(info_dict) == 0:
                             ydl.extract_info(url)

--- a/tubeup/TubeUp.py
+++ b/tubeup/TubeUp.py
@@ -176,12 +176,16 @@ class TubeUp(object):
 
                     if info_dict.get('_type', 'video') == 'playlist':
                         for entry in info_dict['entries']:
+                            if ydl.in_download_archive(entry):
+                                continue
                             if check_if_ia_item_exists(entry) == 0:
                                 ydl.extract_info(entry['webpage_url'])
                                 downloaded_files_basename.update(self.create_basenames_from_ydl_info_dict(ydl, entry))
                             else:
                                 ydl.record_download_archive(entry)
                     else:
+                        if ydl.in_download_archive(entry):
+                            continue
                         if check_if_ia_item_exists(info_dict) == 0:
                             ydl.extract_info(url)
                             downloaded_files_basename.update(self.create_basenames_from_ydl_info_dict(ydl, info_dict))


### PR DESCRIPTION
Closes #231.
This PR also records and checks for items that already exist in `.ytdlarchive`, so it doesn't spam IA with requests every time you upload.