### PR TITLE
Add newline before "Downloaded %s"

### DIFF
--- a/tubeup/TubeUp.py
+++ b/tubeup/TubeUp.py
@@ -143,7 +143,7 @@ class TubeUp(object):
                 sys.stdout.flush()
 
             if d['status'] == 'finished':
-                msg = 'Downloaded %s' % d['filename']
+                msg = '\nDownloaded %s' % d['filename']
 
                 self.logger.debug(d)
                 self.logger.info(msg)


### PR DESCRIPTION
Intended to fix:

```
[download] 100.0% of 197.78MiB at    6.47MiB/s ETA 00:00Downloaded /Users/brandon/.tubeup/downloads/example_file_1
[download] 100.0% of 11.74MiB at    9.01MiB/s ETA 00:00Downloaded /Users/brandon/.tubeup/downloads/example_file_2
```

Intended output:

```
[download] 100.0% of 197.78MiB at    6.47MiB/s ETA 00:00
Downloaded /Users/brandon/.tubeup/downloads/example_file_1
[download] 100.0% of 11.74MiB at    9.01MiB/s ETA 00:00
Downloaded /Users/brandon/.tubeup/downloads/example_file_2
```
