### PR TITLE
Prefer .webm format; still needs testing.

### DIFF
--- a/tubeup/TubeUp.py
+++ b/tubeup/TubeUp.py
@@ -258,6 +258,7 @@ class TubeUp(object):
         ydl_opts = {
             'outtmpl': os.path.join(self.dir_path['downloads'],
                                     self.output_template),
+            'format': 'bestvideo*[ext=webm]+bestaudio/bestvideo*+bestaudio/best',
             'restrictfilenames': True,
             'quiet': not self.verbose,
             'verbose': self.verbose,


### PR DESCRIPTION
Wayback Archive doesn't have native support for MKV files.  However, I found that yt-dlp prefers to download them by default.