### PR TITLE
Repaired Fatal Error for Nonexistent URLs

### DIFF
--- a/tubeup/TubeUp.py
+++ b/tubeup/TubeUp.py
@@ -171,6 +171,8 @@ class TubeUp(object):
 
                     if info_dict.get('_type', 'video') == 'playlist':
                         for entry in info_dict['entries']:
+                            if not entry:
+                                continue
                             if ydl.in_download_archive(entry):
                                 continue
                             if check_if_ia_item_exists(entry) == 0:
@@ -179,6 +181,8 @@ class TubeUp(object):
                             else:
                                 ydl.record_download_archive(entry)
                     else:
+                        if not entry:
+                            continue
                         if ydl.in_download_archive(info_dict):
                             continue
                         if check_if_ia_item_exists(info_dict) == 0:

--- a/tubeup/TubeUp.py
+++ b/tubeup/TubeUp.py
@@ -120,7 +120,7 @@ class TubeUp(object):
 
         def ydl_progress_each(url, entry):
             if not entry:
-                self.logger.warning('[WARN] Video "%s" is not available. Skipping.' % url)
+                self.logger.warning('Video "%s" is not available. Skipping.' % url)
                 return
             if ydl.in_download_archive(entry):
                 return

--- a/tubeup/TubeUp.py
+++ b/tubeup/TubeUp.py
@@ -118,6 +118,18 @@ class TubeUp(object):
                 return 1
             return 0
 
+        def ydl_progress_each(url, entry):
+            if not entry:
+                self.logger.warning('[WARN] Video "%s" is not available. Skipping.' % url)
+                return
+            if ydl.in_download_archive(entry):
+                return
+            if check_if_ia_item_exists(entry) == 0:
+                ydl.extract_info(url)
+                downloaded_files_basename.update(self.create_basenames_from_ydl_info_dict(ydl, entry))
+            else:
+                ydl.record_download_archive(entry)
+
         def ydl_progress_hook(d):
             if d['status'] == 'downloading' and self.verbose:
                 if d.get('_total_bytes_str') is not None:
@@ -171,25 +183,9 @@ class TubeUp(object):
 
                     if info_dict.get('_type', 'video') == 'playlist':
                         for entry in info_dict['entries']:
-                            if not entry:
-                                continue
-                            if ydl.in_download_archive(entry):
-                                continue
-                            if check_if_ia_item_exists(entry) == 0:
-                                ydl.extract_info(entry['webpage_url'])
-                                downloaded_files_basename.update(self.create_basenames_from_ydl_info_dict(ydl, entry))
-                            else:
-                                ydl.record_download_archive(entry)
+                            ydl_progress_each(entry['webpage_url'], entry)
                     else:
-                        if not entry:
-                            continue
-                        if ydl.in_download_archive(info_dict):
-                            continue
-                        if check_if_ia_item_exists(info_dict) == 0:
-                            ydl.extract_info(url)
-                            downloaded_files_basename.update(self.create_basenames_from_ydl_info_dict(ydl, info_dict))
-                        else:
-                            ydl.record_download_archive(info_dict)
+                        ydl_progress_each(url, info_dict)
                 else:
                     info_dict = ydl.extract_info(url)
                     downloaded_files_basename.update(self.create_basenames_from_ydl_info_dict(ydl, info_dict))


### PR DESCRIPTION
For playlists which contain nonexistent videos, entries may return as `None`.  In that case, the program will print this stack trace:
```
An exception just occured, if you found this exception isn't related with any of your connection problem, please report this issue to https://github.com/bibanon/tubeup/issues
Traceback (most recent call last):
  File "C:\Users\USERNAME\AppData\Roaming\Python\Python311\site-packages\tubeup\__main__.py", line 99, in main
    for identifier, meta in tu.archive_urls(URLs, metadata,
  File "C:\Users\USERNAME\AppData\Roaming\Python\Python311\site-packages\tubeup\TubeUp.py", line 417, in archive_urls
    downloaded_file_basenames = self.get_resource_basenames(
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\USERNAME\AppData\Roaming\Python\Python311\site-packages\tubeup\TubeUp.py", line 176, in get_resource_basenames
    if check_if_ia_item_exists(entry) == 0:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\USERNAME\AppData\Roaming\Python\Python311\site-packages\tubeup\TubeUp.py", line 111, in check_if_ia_item_exists
    itemname = sanitize_identifier('%s-%s' % (infodict['extractor'],
                                              ~~~~~~~~^^^^^^^^^^^^^
TypeError: 'NoneType' object is not subscriptable
```

Tested on [this playlist](https://www.youtube.com/playlist?list=PLO5PZUR0wDLCLlLa34f-Gc7M5l1bWiBWF), which has one unavailable video.