### PR TITLE
Idempotent runs by locally tracking successful uploads (😘)

### DIFF
--- a/tubeup/TubeUp.py
+++ b/tubeup/TubeUp.py
@@ -309,16 +309,21 @@ class TubeUp(object):
 
         return ydl_opts
 
-    def upload_ia(self, videobasename, custom_meta=None):
+    def upload_ia(self, videobasename, use_upload_archive=False, custom_meta=None):
         """
         Upload video to archive.org.
 
-        :param videobasename:  A video base name.
-        :param custom_meta:    A custom meta, will be used by internetarchive
-                               library when uploading to archive.org.
-        :return:               A tuple containing item name and metadata used
-                               when uploading to archive.org and whether the item
-                               already exists.
+        :param videobasename:         A video base name.
+        :param use_upload_archive:    Record the video url to the upload archive.
+                                      This will upload only videos not listed in
+                                      the archive file. Record the IDs of all
+                                      uploaded videos in it.
+        :param custom_meta:           A custom meta, will be used by internetarchive
+                                      library when uploading to archive.org.
+        :return:                      A tuple containing item name and metadata used
+                                      when uploading to archive.org and whether the item
+                                      already exists. A null item name means upload
+                                      didn't happened.
         """
         json_metadata_filepath = videobasename + '.info.json'
         with open(json_metadata_filepath, 'r', encoding='utf-8') as f:
@@ -333,6 +338,12 @@ class TubeUp(object):
         itemname = get_itemname(vid_meta)
         metadata = self.create_archive_org_metadata_from_youtubedl_meta(
             vid_meta)
+
+        if use_upload_archive:
+            ydl = YoutubeDL({'download_archive': os.path.join(self.dir_path['root'], '.iauparchive')})
+            if ydl.in_download_archive(vid_meta):
+                self.logger.debug('Skipping already uploaded video: %s', metadata['title'])
+                return None, metadata
 
         # Delete empty description file
         description_file_path = videobasename + '.description'
@@ -375,9 +386,12 @@ class TubeUp(object):
             raise Exception(msg)
 
         item.upload(files_to_upload, metadata=metadata, retries=9001,
-                    request_kwargs=dict(timeout=9001), delete=True,
+                    request_kwargs=dict(timeout=9001), delete=not use_upload_archive,
                     verbose=self.verbose, access_key=s3_access_key,
                     secret_key=s3_secret_key)
+
+        if use_upload_archive:
+            ydl.record_download_archive(vid_meta)
 
         return itemname, metadata
 
@@ -385,6 +399,7 @@ class TubeUp(object):
                      cookie_file=None, proxy=None,
                      ydl_username=None, ydl_password=None,
                      use_download_archive=False,
+                     use_upload_archive=False,
                      ignore_existing_item=False):
         """
         Download and upload videos from youtube_dl supported sites to
@@ -404,6 +419,10 @@ class TubeUp(object):
                                       This will download only videos not listed in
                                       the archive file. Record the IDs of all
                                       downloaded videos in it.
+        :param use_upload_archive:    Record the video url to the upload archive.
+                                      This will upload only videos not listed in
+                                      the archive file. Record the IDs of all
+                                      uploaded videos in it.
         :param ignore_existing_item:  Ignores the check for existing items on archive.org.
         :return:                      Tuple containing identifier and metadata of the
                                       file that has been uploaded to archive.org.
@@ -412,7 +431,7 @@ class TubeUp(object):
             urls, cookie_file, proxy, ydl_username, ydl_password, use_download_archive,
             ignore_existing_item)
         for basename in downloaded_file_basenames:
-            identifier, meta = self.upload_ia(basename, custom_meta)
+            identifier, meta = self.upload_ia(basename, use_upload_archive, custom_meta)
             yield identifier, meta
 
     @staticmethod

--- a/tubeup/__main__.py
+++ b/tubeup/__main__.py
@@ -24,6 +24,7 @@ Usage:
                   [--proxy <prox>]
                   [--quiet] [--debug]
                   [--use-download-archive]
+                  [--use-upload-archive]
                   [--output <output>]
                   [--ignore-existing-item]
   tubeup -h | --help
@@ -45,6 +46,10 @@ Options:
                                This will download only videos not listed in
                                the archive file. Record the IDs of all
                                downloaded videos in it.
+  -U --use-upload-archive      Record the video url to the upload archive.
+                               This will upload only videos not listed in
+                               the archive file. Record the IDs of all
+                               uploaded videos in it.
   -q --quiet                   Just print errors.
   -d --debug                   Print all logs to stdout.
   -o --output <output>         Youtube-dlc output template.
@@ -75,6 +80,7 @@ def main():
     quiet_mode = args['--quiet']
     debug_mode = args['--debug']
     use_download_archive = args['--use-download-archive']
+    use_upload_archive = args['--use-upload-archive']
     ignore_existing_item = args['--ignore-existing-item']
 
     if debug_mode:
@@ -100,10 +106,15 @@ def main():
                                                 cookie_file, proxy_url,
                                                 username, password,
                                                 use_download_archive,
+                                                use_upload_archive,
                                                 ignore_existing_item):
-            print('\n:: Upload Finished. Item information:')
-            print('Title: %s' % meta['title'])
-            print('Item URL: https://archive.org/details/%s\n' % identifier)
+            if identifier:
+                print('\n:: Upload Finished. Item information:')
+                print('Title: %s' % meta['title'])
+                print('Item URL: https://archive.org/details/%s\n' % identifier)
+            else:
+                print('\n:: Upload skipped. Item information:')
+                print('Title: %s' % meta['title'])
     except Exception:
         print('\n\033[91m'  # Start red color text
               'An exception just occured, if you found this '


### PR DESCRIPTION
... the same way `yt-dlp` keep track of downloaded items.

- Amend #19 by adding optional idempotency between runs: While concurrent instances can still rely on a "clean" `download` directory (#19) single-instance nodes can now use `--use-upload-archive` to avoid source files removal. Subsequent runs of `tubeup` will politely omit files already uploaded.

- Fixes #23 (also requested in #233)
- NB: `upload_ia()` may now return `None` instead of `raising` (paves the way to fix #36 or #109)
- NB: most of the diff is tests and argument handling. Only `upload_ia` behavior is actually change (if the new option is passed)