### PR TITLE
yt-dlp flags spring cleaning

### DIFF
--- a/tubeup/TubeUp.py
+++ b/tubeup/TubeUp.py
@@ -269,7 +269,6 @@ class TubeUp(object):
             'writeinfojson': True,
             'writedescription': True,
             'writethumbnail': True,
-            'writeannotations': True,
             'writesubtitles': True,
             'allsubtitles': True,
             'ignoreerrors': True,  # Geo-blocked,
@@ -282,11 +281,6 @@ class TubeUp(object):
             'nooverwrites': True,  # Don't touch what's already been
                                    # downloaded speeds things
             'consoletitle': True,   # Download percentage in console title
-            'prefer_ffmpeg': True,  # `ffmpeg` is better than `avconv`,
-                                    # let's prefer it's use
-            # Warns on out of date youtube-dl script, helps debugging for
-            # youtube-dl devs
-            'call_home': False,
             'logger': self.logger,
             'progress_hooks': [ydl_progress_hook]
         }


### PR DESCRIPTION
- Annotations are dead and not used on Youtube, it's safe to remove this flag. No extractors use annotations.
- Delete call-home functionality to annoy about downloader updates from Youtube-dl days. We don't use that downloader anymore and that functionality isn't ideal and wasn't a good idea for me to put in.
- YT-DLP uses ffmpeg by default and avconv wasa dead project back in 2015