### PR TITLE
Change this forks "Scanner" tag to something different

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,15 @@ Tubeup - a multi-VOD service to Archive.org uploader
 
 It was designed by the [Bibliotheca Anonoma](https://github.com/bibanon/bibanon/wiki) to archive single videos, playlists (see warning below about more than video uploads) or accounts to the Internet Archive.
 
+## Changes specific to this fork
+- Clean-up IP addresses contained by Youtube-generated info files before IA upload
+- Do not abort after a failure but try the next item + saner timeout values
+- Accept arbitrary yt-dlp options (⚠️)
+- Can upload existing resource (⚠️ under certain strict condition, see --help and a52031c)
+- Can upload existing resource based on a local JSON info file
+- More efficient at proceessing a large number of files/URL
+- Broken testsuite (⚠️)
+
 ## Prerequisites
 
 This script strongly recommends Linux or some sort of POSIX system (such as macOS), preferably from a rented VPS and not your personal machine or phone.
@@ -31,7 +40,7 @@ For Debian/Ubuntu:
    At a minimum Python 3.8 and up is required (latest Python preferred).
 
 ```
-   python3 -m pip install -U pip tubeup
+   python3 -m pip install -U pip git+https://github.com/drzraf/tubeup
 ```
 
 3. If you don't already have an Internet Archive account, [register for one](https://archive.org/account/login.createaccount.php) to give the script upload privileges.

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
     },
     install_requires=[
         'internetarchive',
+        'urllib3==1.26.13',
         'docopt==0.6.2',
         'yt-dlp',
     ]

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     },
     install_requires=[
         'internetarchive',
-        'urllib3==1.26.13',
+        'urllib3',
         'docopt==0.6.2',
         'yt-dlp',
     ]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,8 +5,10 @@ from tubeup.utils import sanitize_identifier, check_is_file_empty, strip_ip_from
 
 current_path = os.path.dirname(os.path.realpath(__file__))
 
+
 def get_testfile_path(name):
     return os.path.join(current_path, 'test_tubeup_files', name)
+
 
 class UtilsTest(unittest.TestCase):
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,12 @@
 import unittest
 import os
-from tubeup.utils import sanitize_identifier, check_is_file_empty
+import json
+from tubeup.utils import sanitize_identifier, check_is_file_empty, strip_ip_from_meta
 
+current_path = os.path.dirname(os.path.realpath(__file__))
+
+def get_testfile_path(name):
+    return os.path.join(current_path, 'test_tubeup_files', name)
 
 class UtilsTest(unittest.TestCase):
 
@@ -48,3 +53,14 @@ class UtilsTest(unittest.TestCase):
                 FileNotFoundError,
                 r"^Path 'file_that_doesnt_exist.txt' doesn't exist$"):
             check_is_file_empty('file_that_doesnt_exist.txt')
+
+    def test_strip_ip_from_meta(self):
+        with open(get_testfile_path(
+                'Mountain_3_-_Video_Background_HD_1080p-6iRV8liah8A.'
+                'info.json')
+        ) as f:
+            vid_meta = json.load(f)
+            mod, new_meta = strip_ip_from_meta(vid_meta)
+            self.assertTrue(mod)
+            self.assertNotEqual(f.read(), json.dumps(new_meta))
+            self.assertNotRegex(json.dumps(new_meta), r'36\.73\.93\.234')

--- a/tubeup/TubeUp.py
+++ b/tubeup/TubeUp.py
@@ -232,6 +232,8 @@ class TubeUp(object):
 
         if info_type == 'playlist':
             # Iterate and get the filenames through the playlist
+            if 'entries' not in info_dict:
+                return set()
             for video in info_dict['entries']:
                 filenames.add(ydl.prepare_filename(video))
         else:

--- a/tubeup/TubeUp.py
+++ b/tubeup/TubeUp.py
@@ -307,11 +307,6 @@ class TubeUp(object):
         with open(json_metadata_filepath, 'r', encoding='utf-8') as f:
             vid_meta = json.load(f)
 
-        mod, new_meta = strip_ip_from_meta(vid_meta)
-        if mod:
-            with open(json_metadata_filepath, 'w') as f:
-                json.dump(new_meta, f)
-
         # Exit if video download did not complete, don't upload .part files to IA
         # One glob() + fnmatch() is ten times less expensive than 8 globs(),
         # (Half a second vs 5 seconds on 250k files, what is significant when resuming large playlists)
@@ -371,6 +366,11 @@ class TubeUp(object):
             if self.verbose:
                 print(msg)
             raise Exception(msg)
+
+        mod, new_meta = strip_ip_from_meta(vid_meta)
+        if mod:
+            with open(json_metadata_filepath, 'w') as f:
+                json.dump(new_meta, f)
 
         item.upload(files_to_upload, metadata=metadata, retries=15,
                     request_kwargs=dict(timeout=60), delete=not use_upload_archive,

--- a/tubeup/TubeUp.py
+++ b/tubeup/TubeUp.py
@@ -83,9 +83,6 @@ class TubeUp(object):
         }
 
     def get_resource_basenames(self, urls,
-                               cookie_file=None, proxy_url=None,
-                               ydl_username=None, ydl_password=None,
-                               use_download_archive=False,
                                ignore_existing_item=False,
                                yt_args=[]):
         """
@@ -93,16 +90,6 @@ class TubeUp(object):
 
         :param urls:                  A list of urls that will be downloaded with
                                       youtubedl (or their corresponding info-files)
-        :param cookie_file:           A cookie file for YoutubeDL.
-        :param proxy_url:             A proxy url for YoutubeDL.
-        :param ydl_username:          Username that will be used to download the
-                                      resources with youtube_dl.
-        :param ydl_password:          Password of the related username, will be used
-                                      to download the resources with youtube_dl.
-        :param use_download_archive:  Record the video url to the download archive.
-                                      This will download only videos not listed in
-                                      the archive file. Record the IDs of all
-                                      downloaded videos in it.
         :param ignore_existing_item:  Ignores the check for existing items on archive.org.
         :param yt_args:               Additional parameters passed to yt-dlp.
         :return:                      Set of videos basename that has been downloaded.
@@ -171,10 +158,7 @@ class TubeUp(object):
                 if self.verbose:
                     print(msg)
 
-        ydl_opts = self.generate_ydl_options(ydl_progress_hook,
-                                             cookie_file, proxy_url,
-                                             ydl_username, ydl_password,
-                                             use_download_archive)
+        ydl_opts = self.generate_ydl_options(ydl_progress_hook)
 
         # Default yt-dlp overriden by tubeup specific options
         yt_args.update(ydl_opts)
@@ -250,11 +234,6 @@ class TubeUp(object):
 
     def generate_ydl_options(self,
                              ydl_progress_hook,
-                             cookie_file=None,
-                             proxy_url=None,
-                             ydl_username=None,
-                             ydl_password=None,
-                             use_download_archive=False,
                              ydl_output_template=None):
         """
         Generate a dictionary that contains options that will be used
@@ -262,16 +241,6 @@ class TubeUp(object):
 
         :param ydl_progress_hook:     A function that will be called during the
                                       download process by youtube_dl.
-        :param proxy_url:             A proxy url for YoutubeDL.
-        :param ydl_username:          Username that will be used to download the
-                                      resources with youtube_dl.
-        :param ydl_password:          Password of the related username, will be
-                                      used to download the resources with
-                                      youtube_dl.
-        :param use_download_archive:  Record the video url to the download archive.
-                                      This will download only videos not listed in
-                                      the archive file. Record the IDs of all
-                                      downloaded videos in it.
         :return:                      A dictionary that contains options that will
                                       be used by youtube_dl.
         """
@@ -309,22 +278,6 @@ class TubeUp(object):
             'logger': self.logger,
             'progress_hooks': [ydl_progress_hook]
         }
-
-        if cookie_file is not None:
-            ydl_opts['cookiefile'] = cookie_file
-
-        if proxy_url is not None:
-            ydl_opts['proxy'] = proxy_url
-
-        if ydl_username is not None:
-            ydl_opts['username'] = ydl_username
-
-        if ydl_password is not None:
-            ydl_opts['password'] = ydl_password
-
-        if use_download_archive:
-            ydl_opts['download_archive'] = os.path.join(self.dir_path['root'],
-                                                        '.ytdlarchive')
 
         return ydl_opts
 
@@ -420,9 +373,6 @@ class TubeUp(object):
         return itemname, metadata
 
     def download_urls(self, urls,
-                     cookie_file=None, proxy=None,
-                     ydl_username=None, ydl_password=None,
-                     use_download_archive=False,
                      ignore_existing_item=False,
                      yt_args=[]):
         """
@@ -431,24 +381,13 @@ class TubeUp(object):
 
         :param urls:                  List of url or local info files that will
                                       be downloaded and uploaded to archive.org
-        :param cookie_file:           A cookie file for YoutubeDL.
-        :param proxy_url:             A proxy url for YoutubeDL.
-        :param ydl_username:          Username that will be used to download the
-                                      resources with youtube_dl.
-        :param ydl_password:          Password of the related username, will be used
-                                      to download the resources with youtube_dl.
-        :param use_download_archive:  Record the video url to the download archive.
-                                      This will download only videos not listed in
-                                      the archive file. Record the IDs of all
-                                      downloaded videos in it.
         :param ignore_existing_item:  Ignores the check for existing items on archive.org.
         :param yt_args:               Additional parameters passed to yt-dlp.
         :return:                      Tuple containing identifier and metadata of the
                                       file that has been uploaded to archive.org.
         """
         downloaded_file_basenames = self.get_resource_basenames(
-            urls, cookie_file, proxy, ydl_username, ydl_password, use_download_archive,
-            ignore_existing_item, yt_args)
+            urls, ignore_existing_item, yt_args)
         self.logger.debug('Archiving files from %d videos: %s', len(downloaded_file_basenames), downloaded_file_basenames)
         return downloaded_file_basenames
 

--- a/tubeup/TubeUp.py
+++ b/tubeup/TubeUp.py
@@ -282,8 +282,6 @@ class TubeUp(object):
             'progress_with_newline': True,
             'forcetitle': True,
             'continuedl': True,
-            'retries': 9001,
-            'fragment_retries': 9001,
             'forcejson': False,
             'writeinfojson': True,
             'writedescription': True,
@@ -409,8 +407,8 @@ class TubeUp(object):
                 print(msg)
             raise Exception(msg)
 
-        item.upload(files_to_upload, metadata=metadata, retries=9001,
-                    request_kwargs=dict(timeout=9001), delete=not use_upload_archive,
+        item.upload(files_to_upload, metadata=metadata, retries=15,
+                    request_kwargs=dict(timeout=60), delete=not use_upload_archive,
                     verbose=self.verbose, access_key=s3_access_key,
                     secret_key=s3_secret_key)
 

--- a/tubeup/TubeUp.py
+++ b/tubeup/TubeUp.py
@@ -10,7 +10,7 @@ import internetarchive
 from internetarchive.config import parse_config_file
 from datetime import datetime
 from yt_dlp import YoutubeDL
-from .utils import (get_itemname, check_is_file_empty,
+from .utils import (get_itemname, check_is_file_empty, strip_ip_from_meta,
                     EMPTY_ANNOTATION_FILE)
 from logging import getLogger
 from urllib.parse import urlparse
@@ -323,6 +323,11 @@ class TubeUp(object):
         json_metadata_filepath = videobasename + '.info.json'
         with open(json_metadata_filepath, 'r', encoding='utf-8') as f:
             vid_meta = json.load(f)
+
+        mod, new_meta = strip_ip_from_meta(vid_meta)
+        if mod:
+            with open(json_metadata_filepath, 'w') as f:
+                json.dump(new_meta, f)
 
         # Exit if video download did not complete, don't upload .part files to IA
         for ext in ['*.part', '*.f303.*', '*.f302.*', '*.ytdl', '*.f251.*', '*.248.*', '*.f247.*', '*.temp']:

--- a/tubeup/__main__.py
+++ b/tubeup/__main__.py
@@ -123,10 +123,8 @@ def main():
 
     metadata = internetarchive.cli.argparser.get_args_dict(args['--metadata'])
 
-    tu = TubeUp(verbose=not quiet_mode,
-                output_template=args['--output'])
-
-    downloaded_file_basenames = tu.download_urls(URLs, ignore_existing_item, yt_args)
+    tu = TubeUp(verbose=not quiet_mode, output_template=args['--output'], yt_args=yt_args)
+    downloaded_file_basenames = tu.download_urls(URLs, ignore_existing_item)
 
     failures = []
     for basename in downloaded_file_basenames:

--- a/tubeup/utils.py
+++ b/tubeup/utils.py
@@ -42,9 +42,9 @@ def strip_ip_from_url(url):
     if u.query != '':
         qs = parse_qs(u.query)
         try:
-            del(qs['ip'])
+            del (qs['ip'])
             u = u._replace(query=urlencode(qs, True))
-        except:
+        except KeyError:
             pass
     return u.geturl()
 

--- a/tubeup/utils.py
+++ b/tubeup/utils.py
@@ -1,5 +1,6 @@
 import os
 import re
+from urllib.parse import urlparse, parse_qs, urlencode
 
 
 EMPTY_ANNOTATION_FILE = ('<?xml version="1.0" encoding="UTF-8" ?>'
@@ -29,3 +30,39 @@ def check_is_file_empty(filepath):
         return os.stat(filepath).st_size == 0
     else:
         raise FileNotFoundError("Path '%s' doesn't exist" % filepath)
+
+
+def strip_ip_from_url(url):
+    """
+    Strip occurence of IP address as found in path segments like in /ip/1.2.3.4/
+    or in an "ip" query-parameter, like in ?ip=1.2.3.4
+    """
+    u = urlparse(url)
+    u = u._replace(path=re.sub(r'/ip/[^/]+', r'/ip/REDACTED', u.path))
+    if u.query != '':
+        qs = parse_qs(u.query)
+        try:
+            del(qs['ip'])
+            u = u._replace(query=urlencode(qs, True))
+        except:
+            pass
+    return u.geturl()
+
+
+def strip_ip_from_meta(meta):
+    modified = False
+    if 'url' in meta:
+        redacted_url = strip_ip_from_url(meta['url'])
+        if redacted_url != meta['url']:
+            meta['url'] = redacted_url
+            modified = True
+
+    for _format in meta['formats']:
+        for field in ['manifest_url', 'fragment_base_url', 'url']:
+            if field in _format:
+                redacted_url = strip_ip_from_url(_format[field])
+                if redacted_url != _format[field]:
+                    _format[field] = redacted_url
+                    modified = True
+
+    return modified, meta

--- a/tubeup/utils.py
+++ b/tubeup/utils.py
@@ -38,7 +38,7 @@ def strip_ip_from_url(url):
     or in an "ip" query-parameter, like in ?ip=1.2.3.4
     """
     u = urlparse(url)
-    u = u._replace(path=re.sub(r'/ip/[^/]+', r'/ip/REDACTED', u.path))
+    u = u._replace(path=re.sub(r'%26ip%3D[^%]+', r'%26ip%3DREDACTED%', re.sub(r'/ip/[^/]+', r'/ip/REDACTED', u.path)))
     if u.query != '':
         qs = parse_qs(u.query)
         try:


### PR DESCRIPTION
Hi, you haven't enabled the ability to make issues so I'm doing this here.

Every time a item is uploaded to Archive.org the "Scanner" tag on the item lists the script name and version:

```
Scanner:    TubeUp Video Stream Mirroring Application 2023.08.19 
```

BinAnon is requesting you change this, you can make it "tubeup-drzraf" or whatever you want, but not our Scanner ID. Your fork divirges from ours in function significantly, specifically with open yt-dlp flags that allow for non-standard output and we don't want staff or future historians confusing the two.

Please change this ASAP.

Thanks.