### PR TITLE
add usenetrc argument for ydl_opts to allow the oauth plugin to work.

### DIFF
--- a/tubeup/TubeUp.py
+++ b/tubeup/TubeUp.py
@@ -265,8 +265,8 @@ class TubeUp(object):
             'continuedl': True,
             'retries': 9001,
             'fragment_retries': 9001,
-            'usenetrc': True, #use netrc to authenticate. this option requires the existence of
-                              # a ${HOME}/.netrc file for it to work, otherwise it will be ignored
+            'usenetrc': True,  # use netrc to authenticate. this option requires the existence of
+                               # a ${HOME}/.netrc file for it to work, otherwise it will be ignored
             'forcejson': False,
             'writeinfojson': True,
             'writedescription': True,

--- a/tubeup/TubeUp.py
+++ b/tubeup/TubeUp.py
@@ -265,6 +265,8 @@ class TubeUp(object):
             'continuedl': True,
             'retries': 9001,
             'fragment_retries': 9001,
+            'usenetrc': True, #use netrc to authenticate. this option requires the existence of
+                              # a ${HOME}/.netrc file for it to work, otherwise it will be ignored
             'forcejson': False,
             'writeinfojson': True,
             'writedescription': True,


### PR DESCRIPTION
see https://github.com/111100001/tubeup
oauth plugin: https://github.com/coletdjnz/yt-dlp-youtube-oauth2

some yt-dlp users might get their ip blacklisted and youtube will show "Sign in to confirm you’re not a bot. This helps protect our community. Learn more" error

a workaround for this issue is using a yt-dlp plugin (plugin link above)

the argument will have no effect and will be ignored if the ~/.netrc config file does not exist