### PR TITLE
fix dead link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Archive.org users can upload to four open collections:
 * [Community Video](https://archive.org/details/opensource_movies) where the identifier is `opensource_movies`.
 
 Note that care should be taken when uploading entire channels.
-Read the appropriate section [in this guide](https://archive.org/about/faqs.php#Collections) for creating collections, and contact the [collections staff](mailto:collections-service@archive.org) if you're uploading a channel or multiple channels on one subject (gaming or horticulture for example). Internet Archive collections staff will either create a collection for you or merge any uploaded items based on the YouTube uploader name that are already up into a new collection.
+Read the appropriate section [in this guide](https://help.archive.org/help/collections-a-basic-guide/) for creating collections, and contact the [collections staff](mailto:collections-service@archive.org) if you're uploading a channel or multiple channels on one subject (gaming or horticulture for example). Internet Archive collections staff will either create a collection for you or merge any uploaded items based on the YouTube uploader name that are already up into a new collection.
 
 **Dumping entire channels into Community Video is abusive and may get your account locked.** _Talk to the Internet Archive admins first before doing large uploads; it's better to ask for guidence or help first than run afoul of the rules._
 


### PR DESCRIPTION
the link https://archive.org/about/faqs.php#Collections redirects to https://help.archive.org/#Collections but that anchor is no longer present

**solution**: change to https://help.archive.org/help/collections-a-basic-guide/ which contains similar content according to https://web.archive.org/web/20160721011556/https://archive.org/about/faqs.php#Collections

btw, thank you so much for this excellent software :)