### PR TITLE
pyproject.toml: lock internetarchive dep to <5.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 requires-python = ">=3.8"
 license = {file = "LICENSE"}
 dependencies = [
-    "internetarchive",
+    "internetarchive<5.0.0",
     "docopt==0.6.2",
     "yt-dlp",
 ]


### PR DESCRIPTION
Closes #336, the code ought to be updated to the new major API though.