### PR TITLE
maintenance: improve pyproject.toml file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,14 +6,52 @@ build-backend = "setuptools.build_meta"
 name = "tubeup"
 dynamic = ["version"]
 description = "VOD service to Archive.org uploader"
+authors = [
+    {name = "Bibliotheca Anonoma"}
+]
 readme = "README.md"
 requires-python = ">=3.9"
-license = {file = "LICENSE"}
+license = "GPL-3.0-or-later"
+license-files = ["LICENSE"]
 dependencies = [
     "internetarchive",
     "docopt==0.6.2",
+    "yt-dlp[default,curl-cffi]",
+]
+keywords = [
+    "archive.org",
+    "archiving",
+    "bibliotheca anonoma",
+    "internet archive",
+    "vod",
+    "video",
+    "youtube",
+    "youtube-dl",
+    "youtube-dlc",
     "yt-dlp",
 ]
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: Console",
+    "Intended Audience :: End Users/Desktop",
+    "Operating System :: POSIX :: Linux",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: Implementation",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Programming Language :: Python :: Implementation :: PyPy",
+    "Topic :: Multimedia :: Video",
+    "Topic :: Utilities",
+]
+
+[project.urls]
+homepage = "https://github.com/bibanon/tubeup"
+source = "https://github.com/bibanon/tubeup.git"
+issues = "https://github.com/bibanon/tubeup/issues"
 
 [project.scripts]
 tubeup = "tubeup.__main__:main"


### PR DESCRIPTION
This PR adds missing information that is recommended in the [specifications of pyproject.toml](https://packaging.python.org/en/latest/specifications/pyproject-toml). Although it doesn't change any code, I have tested this in multiple environments (pipx, pip, pypy) and it still works.

- Adds missing keys in `[project]`:
    - `authors` (as "Bibliotheca Anonoma")
    - `keywords`
    - `classifiers`
    - `[project.urls]`
        - `homepage` (Links to GitHub repo)
        - `source`
        - `issue`
- Specifies yt-dlp's `curl-cffi` group in dependencies
- Updates `license` key to meet PEP 639 requirements
    - `license`: Uses SPDX license expression (`GPL-3.0-or-later`)
    - `license-files`: Points to `LICENSE` file

Some further improvement could be made in a later PR / commit. Adding people in the `maintainers` key [would require an email address](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#authors-maintainers) alongside the name for it to fully work. I do not want to add people who maintain this repo into the key without consent.