### PR TITLE
[fix] resolve -p short option collision between --proxy and --password

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Arguments:
   
 Options:
   -h --help                    Show this screen.
-  -p --proxy <prox>            Use a proxy while uploading.
+  -x --proxy <prox>            Use a proxy while uploading.
   -u --username <user>         Provide a username, for sites like Nico Nico Douga.
   -p --password <pass>         Provide a password, for sites like Nico Nico Douga.
   -a --use-download-archive    Record the video url to the download archive.

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,20 @@
+import docopt
+
+import tubeup.__main__ as cli
+
+
+def test_proxy_short_option_sets_proxy():
+    args = docopt.docopt(
+        cli.__doc__,
+        argv=['-x', 'socks5://localhost:9050', 'https://example.com/watch?v=abc123'])
+
+    assert args['--proxy'] == 'socks5://localhost:9050'
+
+
+def test_password_short_option_sets_password():
+    args = docopt.docopt(
+        cli.__doc__,
+        argv=['-p', 'secret', 'https://example.com/watch?v=abc123'])
+
+    assert args['--password'] == 'secret'
+    assert args['--proxy'] is None

--- a/tubeup/__main__.py
+++ b/tubeup/__main__.py
@@ -40,7 +40,7 @@ Arguments:
 
 Options:
   -h --help                    Show this screen.
-  -p --proxy <prox>            Use a proxy while uploading.
+  -x --proxy <prox>            Use a proxy while uploading.
   -u --username <user>         Provide a username, for sites like Nico Nico Douga.
   -p --password <pass>         Provide a password, for sites like Nico Nico Douga.
   -a --use-download-archive    Record the video url to the download archive.


### PR DESCRIPTION
## Summary

The `Options` section in the CLI docstring assigned `-p` to both
`--proxy` and `--password`. Docopt resolves the conflict by taking the
first match, so `-p <val>` silently mapped to `--proxy` and the `-p`
alias for `--password` never worked.

This PR moves `--proxy` to `-x`, following the `curl` convention
(`curl -x` / `curl --proxy`), which frees `-p` for exclusive use as the
`--password` alias.

## Changes

- Change `--proxy` short option from `-p` to `-x` in the CLI docstring.
- Update the README usage block to match.
- Add parser tests verifying `-x` sets `--proxy` and `-p` sets
  `--password` (and not `--proxy`), guarding against regression.

## Breaking change

Scripts or shell aliases that passed `-p <proxy-url>` for proxy must
switch to `-x <proxy-url>` or the long form `--proxy <proxy-url>`.

## Testing

```
pytest tests/ -q
flake8
```

## Test upload
The fix does not affect functionality of TubeUp:
https://archive.org/details/youtube-1CIMGTO6aFc
https://archive.org/details/youtube-HaQiFAWxDxM